### PR TITLE
Add systemd-resolved config

### DIFF
--- a/systemd-resolved/resolved.conf
+++ b/systemd-resolved/resolved.conf
@@ -1,0 +1,35 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it under the
+#  terms of the GNU Lesser General Public License as published by the Free
+#  Software Foundation; either version 2.1 of the License, or (at your option)
+#  any later version.
+#
+# Entries in this file show the compile time defaults. Local configuration
+# should be created by either modifying this file, or by creating "drop-ins" in
+# the resolved.conf.d/ subdirectory. The latter is generally recommended.
+# Defaults can be restored by simply deleting this file and all drop-ins.
+#
+# Use 'systemd-analyze cat-config systemd/resolved.conf' to display the full config.
+#
+# See resolved.conf(5) for details.
+
+[Resolve]
+# Some examples of DNS servers which may be used for DNS= and FallbackDNS=:
+# Cloudflare: 1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
+# Google:     8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
+# Quad9:      9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+DNS=174.138.29.175#dot.tiar.app
+#DNS=1.1.1.1
+#FallbackDNS=
+Domains=~
+#DNSSEC=no
+DNSOverTLS=yes
+#MulticastDNS=no
+#LLMNR=no
+#Cache=no-negative
+#CacheFromLocalhost=no
+#DNSStubListener=yes
+#DNSStubListenerExtra=
+#ReadEtcHosts=yes
+#ResolveUnicastSingleLabel=no


### PR DESCRIPTION
Buat pengguna Linux dengan init systemd, cara penggunaannya tinggal copy config ke `/etc/systemd/resolved.conf`

pastiin juga service `systemd-resolved` jalan & sudah direstart setelah mengcopy config tsb & file `/etc/resolv.conf` di link ke `/run/systemd/resolve/stub-resolv.conf`